### PR TITLE
Fix check for pmu support

### DIFF
--- a/reverie-ptrace/src/perf.rs
+++ b/reverie-ptrace/src/perf.rs
@@ -522,6 +522,7 @@ fn test_perf_pmu_support() -> bool {
         }
         Err(Errno::ENOENT) => info!("Perf feature check failed due to ENOENT"),
         Err(Errno::EPERM) => info!("Perf feature check failed due to EPERM"),
+        Err(Errno::EACCES) => info!("Perf feature check failed due to EACCES"),
         Err(e) => panic!("Unexpected error during perf feature check: {}", e),
     }
     false


### PR DESCRIPTION
GitHub ubuntu VMs return EACCES (i.e., it's there but we don't have permissions).