### PR TITLE
Fix import in `reverie_memory::LocalMemory::new` doctest.

### DIFF
--- a/reverie-memory/src/local.rs
+++ b/reverie-memory/src/local.rs
@@ -26,7 +26,7 @@ impl LocalMemory {
     ///
     /// # Example
     /// ```
-    /// # use reverie_syscalls::LocalMemory;
+    /// # use reverie_memory::LocalMemory;
     /// let memory = LocalMemory::new();
     /// ```
     pub fn new() -> Self {


### PR DESCRIPTION
When https://github.com/facebookexperimental/reverie/commit/dba0b5b9b7827098d4d8b128ceb43072f92b3603 moved `LocalMemory` into the standalone `reverie-memory` crate, a doctest import was not updated.