### PR TITLE
ci: Fix clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,4 +66,4 @@ jobs:
         with:
             components: clippy
       - name: Run cargo clippy
-        run: cargo clippy all-features -- -Dclippy::all
+        run: cargo clippy --all-features -- -Dclippy::all

--- a/reverie-examples/chaos.rs
+++ b/reverie-examples/chaos.rs
@@ -123,17 +123,17 @@ impl Tool for ChaosTool {
                     *guest.thread_state_mut() = true;
 
                     // XXX: inject a signal like SIGINT?
-                    let ret = Err(Errno::ERESTARTSYS);
+                    let err = Errno::ERESTARTSYS;
 
                     eprintln!(
                         "[pid={}, n={}] {} = {}",
                         guest.pid(),
                         count,
                         syscall.display(&memory),
-                        ret.unwrap_or_else(|errno| -errno.into_raw() as i64)
+                        -err.into_raw() as i64
                     );
 
-                    return Ok(ret?);
+                    return Ok(Err(err)?);
                 } else if !config.no_read {
                     // Reduce read length to 1 byte at most.
                     Syscall::Read(read.with_len(1.min(read.len())))

--- a/reverie-examples/counter2.rs
+++ b/reverie-examples/counter2.rs
@@ -139,7 +139,6 @@ impl Tool for CounterLocal {
     ) -> Result<(), Error> {
         let count = self.proc_syscalls.load(Ordering::SeqCst);
         let threads = self.exited_threads.load(Ordering::SeqCst);
-        drop(self);
         debug!(
             "At ExitProc (pid {}), contributing {} to global count.",
             pid, count

--- a/reverie-memory/src/lib.rs
+++ b/reverie-memory/src/lib.rs
@@ -151,10 +151,7 @@ pub trait MemoryAccess {
         T: Sized,
     {
         let buf = unsafe {
-            ::core::slice::from_raw_parts_mut(
-                buf.as_mut_ptr() as *mut u8,
-                buf.len() * mem::size_of::<T>(),
-            )
+            ::core::slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut u8, mem::size_of_val(buf))
         };
 
         self.read_exact(addr.cast::<u8>(), buf)
@@ -167,10 +164,7 @@ pub trait MemoryAccess {
         T: Sized,
     {
         let buf = unsafe {
-            ::core::slice::from_raw_parts(
-                buf.as_ptr() as *const u8,
-                buf.len() * mem::size_of::<T>(),
-            )
+            ::core::slice::from_raw_parts(buf.as_ptr() as *const u8, mem::size_of_val(buf))
         };
 
         self.write_exact(addr.cast::<u8>(), buf)

--- a/reverie-ptrace/src/gdbstub/commands/base/_vFile.rs
+++ b/reverie-ptrace/src/gdbstub/commands/base/_vFile.rs
@@ -44,7 +44,7 @@ impl From<FileStat> for HostioStat {
             st_dev: stat.st_dev as u32,
             st_ino: stat.st_ino as u32,
             st_nlink: stat.st_nlink as u32,
-            st_mode: stat.st_mode as u32,
+            st_mode: stat.st_mode,
             st_uid: stat.st_uid,
             st_gid: stat.st_gid,
             st_rdev: stat.st_rdev as u32,

--- a/reverie-ptrace/src/gdbstub/server.rs
+++ b/reverie-ptrace/src/gdbstub/server.rs
@@ -254,7 +254,7 @@ impl GdbServerImpl {
         // could get timeout. Some requests such as `g' needs IPC with a
         // gdb session, which only becomes ready later.
         if let Some(server_rx) = self.server_rx.take() {
-            let _ = server_rx.await.map_err(|_| Error::GdbServerNotStarted)?;
+            server_rx.await.map_err(|_| Error::GdbServerNotStarted)?;
             let mut session = self.session.take().ok_or(Error::SessionNotStarted)?;
             let run_session = session.run();
             let run_loop = self.relay_gdb_packets();

--- a/reverie-ptrace/src/gdbstub/session.rs
+++ b/reverie-ptrace/src/gdbstub/session.rs
@@ -733,12 +733,12 @@ impl Session {
                 },
                 reply_tx,
             );
-            let _ = request_tx
+            request_tx
                 .send(request)
                 .await
                 .map_err(|_| Error::GdbRequestSendError)?;
-            let reply = reply_rx.await.map_err(|_| Error::GdbRequestRecvError)??;
-            Ok(reply)
+            reply_rx.await.map_err(|_| Error::GdbRequestRecvError)??;
+            Ok(())
         })
         .await
     }
@@ -762,9 +762,9 @@ impl Session {
                 .send(request)
                 .await
                 .map_err(|_| Error::GdbRequestSendError)?;
-            let reply = reply_rx.await.map_err(|_| Error::GdbRequestRecvError)??;
+            reply_rx.await.map_err(|_| Error::GdbRequestRecvError)??;
 
-            Ok(reply)
+            Ok(())
         })
         .await
     }
@@ -777,7 +777,7 @@ impl Session {
                 .ok_or(Error::SessionNotStarted)?;
             let (reply_tx, reply_rx) = oneshot::channel();
             let request = GdbRequest::ReadInferiorMemory(addr, size, reply_tx);
-            let _ = request_tx
+            request_tx
                 .send(request)
                 .await
                 .map_err(|_| Error::GdbRequestSendError)?;
@@ -801,12 +801,12 @@ impl Session {
                 .ok_or(Error::SessionNotStarted)?;
             let (reply_tx, reply_rx) = oneshot::channel();
             let request = GdbRequest::WriteInferiorMemory(addr, size, data, reply_tx);
-            let _ = request_tx
+            request_tx
                 .send(request)
                 .await
                 .map_err(|_| Error::GdbRequestSendError)?;
-            let reply = reply_rx.await.map_err(|_| Error::GdbRequestRecvError)??;
-            Ok(reply)
+            reply_rx.await.map_err(|_| Error::GdbRequestRecvError)??;
+            Ok(())
         })
         .await
     }
@@ -819,7 +819,7 @@ impl Session {
                 .ok_or(Error::SessionNotStarted)?;
             let (reply_tx, reply_rx) = oneshot::channel();
             let request = GdbRequest::ReadRegisters(reply_tx);
-            let _ = request_tx
+            request_tx
                 .send(request)
                 .await
                 .map_err(|_| Error::GdbRequestSendError)?;
@@ -840,12 +840,12 @@ impl Session {
             let core_regs: CoreRegs =
                 bincode::deserialize(regs).map_err(|_| CommandParseError::MalformedRegisters)?;
             let request = GdbRequest::WriteRegisters(core_regs, reply_tx);
-            let _ = request_tx
+            request_tx
                 .send(request)
                 .await
                 .map_err(|_| Error::GdbRequestSendError)?;
-            let reply = reply_rx.await.map_err(|_| Error::GdbRequestRecvError)??;
-            Ok(reply)
+            reply_rx.await.map_err(|_| Error::GdbRequestRecvError)??;
+            Ok(())
         })
         .await
     }

--- a/reverie-ptrace/src/stack.rs
+++ b/reverie-ptrace/src/stack.rs
@@ -52,7 +52,7 @@ impl GuestStack {
         }
         let task = Stopped::new_unchecked(pid);
         let rsp = task.getregs()?.stack_ptr() as usize;
-        let top = rsp - REDZONE_SIZE as usize;
+        let top = rsp - REDZONE_SIZE;
         Ok(GuestStack {
             top,
             sp: top,
@@ -106,7 +106,7 @@ impl Stack for GuestStack {
     type StackGuard = StackGuard;
 
     fn size(&self) -> usize {
-        (self.top - self.sp) as usize
+        self.top - self.sp
     }
     fn capacity(&self) -> usize {
         self.capacity

--- a/reverie-ptrace/src/timer.rs
+++ b/reverie-ptrace/src/timer.rs
@@ -355,10 +355,20 @@ impl ActiveEvent {
             ActiveEvent::Precise {
                 clock_target,
                 offset: _,
-            } => (clock_target.saturating_sub(curr_clock) > MAX_SINGLE_STEP_COUNT)
-                .then(|| TimerEventRequest::Precise(*clock_target - curr_clock)),
-            ActiveEvent::Imprecise { clock_min } => (*clock_min > curr_clock)
-                .then(|| TimerEventRequest::Imprecise(*clock_min - curr_clock)),
+            } => {
+                if clock_target.saturating_sub(curr_clock) > MAX_SINGLE_STEP_COUNT {
+                    Some(TimerEventRequest::Precise(*clock_target - curr_clock))
+                } else {
+                    None
+                }
+            }
+            ActiveEvent::Imprecise { clock_min } => {
+                if *clock_min > curr_clock {
+                    Some(TimerEventRequest::Imprecise(*clock_min - curr_clock))
+                } else {
+                    None
+                }
+            }
         }
     }
 }

--- a/reverie-syscalls/src/args/mod.rs
+++ b/reverie-syscalls/src/args/mod.rs
@@ -287,7 +287,7 @@ impl<'a> StatPtr<'a> {
     /// Creates the `StatPtr` from a raw pointer. Returns `None` if the given
     /// pointer is NULL.
     pub fn from_ptr(r: *const libc::stat) -> Option<Self> {
-        AddrMut::from_ptr(r as *const libc::stat).map(StatPtr)
+        AddrMut::from_ptr(r).map(StatPtr)
     }
 }
 
@@ -351,7 +351,7 @@ impl<'a> StatxPtr<'a> {
     /// Creates the `StatxPtr` from a raw pointer. Returns `None` if the given
     /// pointer is NULL.
     pub fn from_ptr(r: *const libc::statx) -> Option<Self> {
-        AddrMut::from_ptr(r as *const libc::statx).map(StatxPtr)
+        AddrMut::from_ptr(r).map(StatxPtr)
     }
 }
 

--- a/reverie-syscalls/src/raw.rs
+++ b/reverie-syscalls/src/raw.rs
@@ -94,21 +94,21 @@ impl FromToRaw for i64 {
 
 impl<'a, T> FromToRaw for Option<Addr<'a, T>> {
     fn from_raw(raw: usize) -> Self {
-        Addr::from_raw(raw as usize)
+        Addr::from_raw(raw)
     }
 
     fn into_raw(self) -> usize {
-        self.map_or(0, |addr| addr.as_raw() as usize)
+        self.map_or(0, |addr| addr.as_raw())
     }
 }
 
 impl<'a, T> FromToRaw for Option<AddrMut<'a, T>> {
     fn from_raw(raw: usize) -> Self {
-        AddrMut::from_raw(raw as usize)
+        AddrMut::from_raw(raw)
     }
 
     fn into_raw(self) -> usize {
-        self.map_or(0, |addr| addr.as_raw() as usize)
+        self.map_or(0, |addr| addr.as_raw())
     }
 }
 
@@ -176,7 +176,7 @@ where
     T: FromToRaw,
 {
     fn from_raw(raw: usize) -> Self {
-        Errno::from_ret(raw).map(|x| T::from_raw(x as usize))
+        Errno::from_ret(raw).map(|x| T::from_raw(x))
     }
 
     fn into_raw(self) -> usize {

--- a/reverie-syscalls/src/syscalls/mod.rs
+++ b/reverie-syscalls/src/syscalls/mod.rs
@@ -1005,7 +1005,7 @@ typed_syscall! {
     }
 }
 
-#[cfg(any(target_arch = "x86_64"))]
+#[cfg(target_arch = "x86_64")]
 typed_syscall! {
     pub struct Clone {
         flags: CloneFlags,

--- a/reverie/src/backtrace/mod.rs
+++ b/reverie/src/backtrace/mod.rs
@@ -278,7 +278,7 @@ impl From<Backtrace> for Vec<Frame> {
 impl fmt::Display for Backtrace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let thread_name = self.thread_name();
-        let thread_name = thread_name.as_ref().map(String::as_str);
+        let thread_name = thread_name.as_deref();
         let thread_name = thread_name.unwrap_or("<unknown name>");
         writeln!(
             f,
@@ -298,7 +298,7 @@ impl fmt::Display for Backtrace {
 impl fmt::Display for PrettyBacktrace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let thread_name = self.thread_name();
-        let thread_name = thread_name.as_ref().map(String::as_str);
+        let thread_name = thread_name.as_deref();
         let thread_name = thread_name.unwrap_or("<unknown name>");
         writeln!(
             f,

--- a/reverie/src/regs.rs
+++ b/reverie/src/regs.rs
@@ -11,17 +11,17 @@
 /// Trait providing reusable display formatting for registers
 pub trait RegDisplay {
     /// Returns a display object associated with a trait implementor
-    fn display<'a>(&'a self) -> Display<'a> {
+    fn display(&self) -> Display<'_> {
         self.display_with_options(Default::default())
     }
 
     /// Return a display object associated with a trait implementor.
     /// Additionally specifis ['RegDisplayOptions'] structure to adjust formatting
-    fn display_with_options<'a>(&'a self, options: RegDisplayOptions) -> Display<'a>;
+    fn display_with_options(&self, options: RegDisplayOptions) -> Display<'_>;
 }
 
 impl RegDisplay for libc::user_regs_struct {
-    fn display_with_options<'a>(&'a self, options: RegDisplayOptions) -> Display<'a> {
+    fn display_with_options(&self, options: RegDisplayOptions) -> Display<'_> {
         Display {
             options,
             regs: self,

--- a/safeptrace/src/lib.rs
+++ b/safeptrace/src/lib.rs
@@ -242,7 +242,7 @@ impl TryWait {
     pub fn assume_stopped(self) -> (Stopped, Event) {
         match self {
             Self::Wait(Wait::Stopped(stopped, event)) => (stopped, event),
-            status => Err(InvalidState(status)).unwrap(),
+            status => panic!("{:?}", InvalidState(status)),
         }
     }
 
@@ -250,7 +250,7 @@ impl TryWait {
     pub fn assume_running(self) -> Running {
         match self {
             Self::Running(running) => running,
-            status => Err(InvalidState(status)).unwrap(),
+            status => panic!("{:?}", InvalidState(status)),
         }
     }
 
@@ -258,7 +258,7 @@ impl TryWait {
     pub fn assume_exited(self) -> (Pid, ExitStatus) {
         match self {
             Self::Wait(Wait::Exited(pid, exit_status)) => (pid, exit_status),
-            status => Err(InvalidState(status)).unwrap(),
+            status => panic!("{:?}", InvalidState(status)),
         }
     }
 }
@@ -314,7 +314,7 @@ impl Wait {
     pub fn assume_stopped(self) -> (Stopped, Event) {
         match self {
             Self::Stopped(stopped, event) => (stopped, event),
-            state => Err(InvalidState(state.into())).unwrap(),
+            state => panic!("{:?}", InvalidState(state.into())),
         }
     }
 
@@ -322,7 +322,7 @@ impl Wait {
     pub fn assume_exited(self) -> (Pid, ExitStatus) {
         match self {
             Self::Exited(pid, exit_status) => (pid, exit_status),
-            state => Err(InvalidState(state.into())).unwrap(),
+            state => panic!("{:?}", InvalidState(state.into())),
         }
     }
 

--- a/safeptrace/src/waitid.rs
+++ b/safeptrace/src/waitid.rs
@@ -42,7 +42,7 @@ fn si_status_signal(info: &libc::siginfo_t) -> Signal {
 
 #[inline]
 fn si_status_event(info: &libc::siginfo_t) -> i32 {
-    (unsafe { info.si_status() } >> 8) as i32
+    (unsafe { info.si_status() }) >> 8
 }
 
 /// Returns the raw siginfo from a waitid call.
@@ -70,6 +70,7 @@ fn waitid_si(waitid_type: IdType, flags: WaitPidFlag) -> Result<libc::siginfo_t,
 }
 
 /// `waitpid` implemented with `waitid`. `waitid` has fewer limitations than `waitpid`.
+#[cfg(feature = "notifier")]
 pub fn waitpid(pid: Pid, flags: WaitPidFlag) -> Result<Option<i32>, Errno> {
     let si = waitid_si(IdType::Pid(pid), flags)?;
 
@@ -82,6 +83,7 @@ pub fn waitpid(pid: Pid, flags: WaitPidFlag) -> Result<Option<i32>, Errno> {
 }
 
 // Converts a siginfo to a more compact status code.
+#[cfg(feature = "notifier")]
 fn siginfo_to_status(si: libc::siginfo_t) -> i32 {
     let si_status = unsafe { si.si_status() };
 


### PR DESCRIPTION
The clippy action has been in a broken state since 1438ff0f2e0b432a2e4da2b320fff8f6f58e6bbe. This fixes the GitHub action and all of the clippy warnings.