### PR TITLE
ci: Fix clippy warnings

### DIFF
--- a/reverie-examples/chunky_print.rs
+++ b/reverie-examples/chunky_print.rs
@@ -74,7 +74,7 @@ impl GlobalTool for ChunkyPrintGlobal {
         let mut mg = self.0.lock().unwrap();
         match m {
             Msg::Print(w, s) => {
-                let v = mg.printbuf.entry(from).or_insert_with(Vec::new);
+                let v = mg.printbuf.entry(from).or_default();
                 v.push((w, s));
             }
             Msg::Tick => {

--- a/reverie-process/src/lib.rs
+++ b/reverie-process/src/lib.rs
@@ -227,9 +227,7 @@ mod tests {
             .trim_end()
             .split('\n')
             .map(|line| {
-                let mut items = line.splitn(2, ':');
-                let first = items.next().unwrap();
-                let second = items.next().unwrap();
+                let (first, second) = line.split_once(':').unwrap();
                 (first, second.trim())
             })
             .collect()
@@ -655,6 +653,7 @@ mod tests {
             .arg("/proc/self/status")
             .seccomp(filter)
             .seccomp_notify()
+            .stdout(Stdio::null())
             .spawn()
             .unwrap();
 

--- a/reverie-process/src/mount.rs
+++ b/reverie-process/src/mount.rs
@@ -292,9 +292,9 @@ impl Mount {
             // a different tmpfs.
             if let Some(src) = &self.source {
                 if FileType::new(src.as_ptr())?.is_dir() {
-                    create_dir_all(&mut self.target, 0o777)?;
+                    create_dir_all(&self.target, 0o777)?;
                 } else {
-                    touch_path(&mut self.target, 0o666, 0o777)?;
+                    touch_path(&self.target, 0o666, 0o777)?;
                 }
             }
         }

--- a/reverie-process/src/seccomp/notif.rs
+++ b/reverie-process/src/seccomp/notif.rs
@@ -283,7 +283,7 @@ impl futures::stream::Stream for SeccompNotif {
 /// currently pending, the operation blocks until an event occurs.
 ///
 /// NOTE: This is only available since Linux 5.0.
-fn seccomp_notif_recv(fd: &mut Fd) -> io::Result<seccomp_notif> {
+fn seccomp_notif_recv(fd: &Fd) -> io::Result<seccomp_notif> {
     // According to the docs, this struct must be zeroed out first.
     let mut response = core::mem::MaybeUninit::<seccomp_notif>::zeroed();
 


### PR DESCRIPTION
Fixes all current clippy warnings[1] so CI is green again.

Fixing the warning `clippy::needless_pass_by_ref_mut` became a little involved. The internal version of clippy isn't recent enough to have this warning and so just doing `#[allow(clippy::needless_pass_by_ref_mut)]` leads to another error. The resulting change fixes the clippy warning and gets rid of some of the shenanigans I was doing to avoid allocating path buffers within the child process.

[1]: https://github.com/facebookexperimental/reverie/actions/runs/6164196219/job/16729396694