### PR TITLE
Fix vdso_get_symbols_info() assertion for ARM64

### DIFF
--- a/reverie-ptrace/src/vdso.rs
+++ b/reverie-ptrace/src/vdso.rs
@@ -221,7 +221,9 @@ fn vdso_get_symbols_info() -> HashMap<&'static str, (u64, usize)> {
                         if let Some((name, _)) =
                             VDSO_SYMBOLS.iter().find(|&(name, _)| name == &sym_name)
                         {
-                            debug_assert!(sym.is_function());
+                            /* __kernel_rt_sigreturn on ARM64 unfortunately is not marked as
+                             * a funtion in VDSO, but as STT_NONE. */
+                            debug_assert!(sym.is_function() || name == &"__kernel_rt_sigreturn");
                             res.insert(*name, (sym.st_value, sym.st_size as usize));
                         }
                     });


### PR DESCRIPTION
On ARM64 I have been seeing test failures:

```
test vdso::tests::vdso_can_find_symbols_info ... FAILED
test vdso::tests::vdso_patch_info_is_valid ... FAILED
```

Looking closer, this was caused by the debug assertion in vdso_get_symbols_info() which asserts that all symbols found in the VDSO are ELF STT_FUNC symbols. Unfortunately, this is not the case on ARM64, because the VDSO's `__kernel_rt_sigreturn` is special and does appear as STT_NONE symbol.

Fixup the debug assertion by special-casing for this special function.

Note: I shortly considered adding an expected symbol type to the `VDSO_SYMBOLS` hashes, but that didn't seem to make sense just to fix this one special case.