### PR TITLE
ci: Make clippy less strict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,4 +66,4 @@ jobs:
         with:
             components: clippy
       - name: Run cargo clippy
-        run: cargo clippy --all-features -- -Dclippy::all
+        run: cargo clippy --all-features


### PR DESCRIPTION
The clippy errors with `clippy::all` aren't too helpful. Plus, with building on nightly, new lints often break CI.