### PR TITLE
upgrading tokio to 1.52.1

### DIFF
--- a/reverie-examples/Cargo.toml
+++ b/reverie-examples/Cargo.toml
@@ -53,5 +53,5 @@ reverie-ptrace = { version = "0.1.0", path = "../reverie-ptrace" }
 reverie-util = { version = "0.1.0", path = "../reverie-util" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/reverie-process/Cargo.toml
+++ b/reverie-process/Cargo.toml
@@ -18,7 +18,7 @@ nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 syscalls = { version = "0.6.18", features = ["serde"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 num_cpus = "1.16"

--- a/reverie-ptrace/Cargo.toml
+++ b/reverie-ptrace/Cargo.toml
@@ -29,7 +29,7 @@ reverie = { version = "0.1.0", path = "../reverie" }
 safeptrace = { version = "0.1.0", path = "../safeptrace", features = ["memory", "notifier"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }

--- a/safeptrace/Cargo.toml
+++ b/safeptrace/Cargo.toml
@@ -23,7 +23,7 @@ thiserror = "2.0.18"
 [dev-dependencies]
 quickcheck = "1.0"
 quickcheck_macros = "1.2.0"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [features]
 default = []


### PR DESCRIPTION
Summary:
X-link: https://github.com/meta-pytorch/monarch/pull/3495

Upgrading `tokio` from `1.50.0` to `1.52.1`.
- All downstream consumers checked with arc rust-check — 0 errors.

Reviewed By: dtolnay

Differential Revision: D101580193
