### PR TITLE
refresh 10 crates to latest compatible versions

### DIFF
--- a/reverie-process/Cargo.toml
+++ b/reverie-process/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-2-Clause"
 
 [dependencies]
 bincode = { version = "2", features = ["serde"] }
-bitflags = { version = "2.11.1", features = ["serde"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde"], default-features = false }
 colored = "2.1.0"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 libc = "0.2.186"

--- a/reverie-syscalls/Cargo.toml
+++ b/reverie-syscalls/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/facebookexperimental/reverie"
 license = "BSD-2-Clause"
 
 [dependencies]
-bitflags = { version = "2.11.1", features = ["serde"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde"], default-features = false }
 derive_more = { version = "1.0.0", features = ["full"] }
 libc = "0.2.186"
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }

--- a/reverie-util/Cargo.toml
+++ b/reverie-util/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-2-Clause"
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 clap = { version = "4.6.0", features = ["derive", "env", "string", "unicode", "wrap_help"] }
 reverie = { version = "0.1.0", path = "../reverie" }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/reverie/Cargo.toml
+++ b/reverie/Cargo.toml
@@ -12,7 +12,7 @@ license = "BSD-2-Clause"
 addr2line = "0.24.2"
 anyhow = "1.0.102"
 async-trait = "0.1.86"
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 byteorder = "1.5"
 lazy_static = "1.5"
 libc = "0.2.186"

--- a/safeptrace/Cargo.toml
+++ b/safeptrace/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/facebookexperimental/reverie"
 license = "BSD-2-Clause"
 
 [dependencies]
-bitflags = { version = "2.11.1", features = ["serde", "std"], default-features = false }
+bitflags = { version = "2.13.0", features = ["serde", "std"], default-features = false }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 lazy_static = "1.5"
 libc = "0.2.186"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/hhvm/pull/9791

X-link: https://github.com/facebook/ocamlrep/pull/93

X-link: https://github.com/facebook/buck2-shims-meta/pull/17

X-link: https://github.com/facebook/flow/pull/9420

X-link: https://github.com/WhatsApp/erlang-language-platform/pull/215

X-link: https://github.com/facebook/buck2/pull/1335

X-link: https://github.com/meta-pytorch/monarch/pull/4193

Refreshes 10 third-party Rust crates to their latest semver-compatible versions. These are dependencies used by the hzdb/metavr CLI (`arvr/apps/hzdb`) that were behind in the shared lockfile; the bumps apply repo-wide since `third-party/rust` is shared.

- `bitflags` `2.11.1` -> `2.13.0`
- `bumpalo` `3.20.2` -> `3.20.3`
- `cc` `1.2.62` -> `1.2.63` (additively vendors `shlex` `2.0.1` as a new transitive of `cc`)
- `chrono` `0.4.44` -> `0.4.45`
- `http` `1.4.0` -> `1.4.1`
- `hyper` `1.9.0` -> `1.10.1`
- `memchr` `2.8.0` -> `2.8.1`
- `reqwest` `0.13.2` -> `0.13.4`
- `unicode-segmentation` `1.13.2` -> `1.13.3`
- `zerocopy` `0.8.48` -> `0.8.50`

All are patch/minor (semver-compatible) bumps requiring no first-party code changes. Mirrored the applicable bumps into the github shim manifest (`fbcode/github/standard/shim/third-party/rust/Cargo.toml`) for `bitflags`, `bumpalo`, `chrono`, `http`, `hyper`, `memchr`, and `unicode-segmentation`. Regenerated with `reindeer vendor`, which also refreshed 255 first-party `Cargo.toml` manifests via autocargo. No first-party Rust source changes were needed.

Differential Revision: D107740437
